### PR TITLE
[fix bug] storing crossattn_cache

### DIFF
--- a/pipeline/causal_diffusion_inference.py
+++ b/pipeline/causal_diffusion_inference.py
@@ -110,8 +110,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
         else:
             # reset cross attn cache
             for block_index in range(self.num_transformer_blocks):
-                self.crossattn_cache_pos[block_index]["is_init"] = False
-                self.crossattn_cache_neg[block_index]["is_init"] = False
+                self.crossattn_cache_pos[block_index]["is_init"].fill_(False)
+                self.crossattn_cache_neg[block_index]["is_init"].fill_(False)
             # reset kv cache
             for block_index in range(len(self.kv_cache_pos)):
                 self.kv_cache_pos[block_index]["global_end_index"] = torch.tensor(
@@ -307,12 +307,12 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
             crossattn_cache_pos.append({
                 "k": torch.zeros([batch_size, 512, 12, 128], dtype=dtype, device=device),
                 "v": torch.zeros([batch_size, 512, 12, 128], dtype=dtype, device=device),
-                "is_init": False
+                "is_init": torch.zeros([1], dtype=torch.bool, device=device)    # False
             })
             crossattn_cache_neg.append({
                 "k": torch.zeros([batch_size, 512, 12, 128], dtype=dtype, device=device),
                 "v": torch.zeros([batch_size, 512, 12, 128], dtype=dtype, device=device),
-                "is_init": False
+                "is_init": torch.zeros([1], dtype=torch.bool, device=device)    # False
             })
 
         self.crossattn_cache_pos = crossattn_cache_pos  # always store the clean cache

--- a/pipeline/causal_inference.py
+++ b/pipeline/causal_inference.py
@@ -123,7 +123,7 @@ class CausalInferencePipeline(torch.nn.Module):
         else:
             # reset cross attn cache
             for block_index in range(self.num_transformer_blocks):
-                self.crossattn_cache[block_index]["is_init"] = False
+                self.crossattn_cache[block_index]["is_init"].fill_(False)
             # reset kv cache
             for block_index in range(len(self.kv_cache1)):
                 self.kv_cache1[block_index]["global_end_index"] = torch.tensor(
@@ -307,6 +307,6 @@ class CausalInferencePipeline(torch.nn.Module):
             crossattn_cache.append({
                 "k": torch.zeros([batch_size, 512, 12, 128], dtype=dtype, device=device),
                 "v": torch.zeros([batch_size, 512, 12, 128], dtype=dtype, device=device),
-                "is_init": False
+                "is_init": torch.zeros([1], dtype=torch.bool, device=device)    # False
             })
         self.crossattn_cache = crossattn_cache

--- a/pipeline/self_forcing_training.py
+++ b/pipeline/self_forcing_training.py
@@ -103,7 +103,7 @@ class SelfForcingTrainingPipeline:
         # else:
         #     # reset cross attn cache
         #     for block_index in range(self.num_transformer_blocks):
-        #         self.crossattn_cache[block_index]["is_init"] = False
+        #         self.crossattn_cache[block_index]["is_init"].fill_(True)
         #     # reset kv cache
         #     for block_index in range(len(self.kv_cache1)):
         #         self.kv_cache1[block_index]["global_end_index"] = torch.tensor(

--- a/pipeline/self_forcing_training.py
+++ b/pipeline/self_forcing_training.py
@@ -262,6 +262,6 @@ class SelfForcingTrainingPipeline:
             crossattn_cache.append({
                 "k": torch.zeros([batch_size, 512, 12, 128], dtype=dtype, device=device),
                 "v": torch.zeros([batch_size, 512, 12, 128], dtype=dtype, device=device),
-                "is_init": False
+                "is_init": torch.zeros([1], dtype=torch.bool, device=device)    # False
             })
         self.crossattn_cache = crossattn_cache

--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -172,12 +172,33 @@ class WanT2VCrossAttention(WanSelfAttention):
         q = self.norm_q(self.q(x)).view(b, -1, n, d)
 
         if crossattn_cache is not None:
-            if not crossattn_cache["is_init"]:
-                crossattn_cache["is_init"] = True
+            if not crossattn_cache["is_init"].item():
                 k = self.norm_k(self.k(context)).view(b, -1, n, d)
                 v = self.v(context).view(b, -1, n, d)
-                crossattn_cache["k"] = k
-                crossattn_cache["v"] = v
+
+                if k.shape != crossattn_cache["k"].shape:
+                    raise RuntimeError(
+                        f"crossattn_cache['k'] shape mismatch: new={tuple(k.shape)} "
+                        f"buf={tuple(crossattn_cache['k'].shape)}"
+                    )
+                if v.shape != crossattn_cache["v"].shape:
+                    raise RuntimeError(
+                        f"crossattn_cache['v'] shape mismatch: new={tuple(v.shape)} "
+                        f"buf={tuple(crossattn_cache['v'].shape)}"
+                    )
+                if k.device != crossattn_cache["k"].device or v.device != crossattn_cache["v"].device:
+                    raise RuntimeError(
+                        f"crossattn_cache device mismatch: new(k/v)={k.device}/{v.device} "
+                        f"buf(k/v)={crossattn_cache['k'].device}/{crossattn_cache['v'].device}"
+                    )
+                if k.dtype != crossattn_cache["k"].dtype:
+                    k = k.to(dtype=crossattn_cache["k"].dtype)
+                if v.dtype != crossattn_cache["v"].dtype:
+                    v = v.to(dtype=crossattn_cache["v"].dtype)
+
+                crossattn_cache["k"].copy_(k)
+                crossattn_cache["v"].copy_(v)
+                crossattn_cache["is_init"].fill_(True)
             else:
                 k = crossattn_cache["k"]
                 v = crossattn_cache["v"]


### PR DESCRIPTION
## Fix: cross-attention cache not persistently updated due to dict rebind

### Problem

During generation with cached cross-attention, `crossattn_cache` was not reliably updated across forward calls, while `kv_cache` behaved correctly.

Specifically:
- `kv_cache` updates (self-attention) persist as expected.
- `crossattn_cache` updates (`is_init`, `k`, `v`) may be silently lost, causing repeated recomputation of cross-attention keys/values.

This leads to:
- Incorrect cache behavior
- Unnecessary recomputation
- Potential performance regression during generation

### Root Cause

The difference comes from how the cache is updated:

- **KV cache** updates are **in-place tensor writes**:

```
kv_cache["k"][:, ...] = ...
kv_cache["global_end_index"].fill_(...)
```
These modify tensor contents and are robust even if the surrounding `dict` is shallow-copied.

- **Cross-attention cache** previously used **dict rebind**:

```
crossattn_cache["k"] = k
crossattn_cache["v"] = v
crossattn_cache["is_init"] = True
```
This rebinds Python object references. If the cache dict is wrapped, copied, or reconstructed (e.g. via kwargs propagation, wrappers, or graph capture), the updates do not propagate back to the original cache.

As a result, `crossattn_cache` updates were not guaranteed to persist, unlike `kv_cache`.

### Fix

- Make cross-attention cache updates **fully in-place**, matching the semantics of `kv_cache`:

  1. Change is_init from Python bool to a device tensor, updated via .fill_()
  2. Write k and v into preallocated cache tensors using .copy_(), instead of rebinding dict entries
  3. Add explicit shape / dtype / device checks to fail fast if assumptions are violated

- Key changes (simplified):

```
# init
"is_init": torch.zeros([1], dtype=torch.bool, device=device)

# forward
if not crossattn_cache["is_init"].item():
    k = ...
    v = ...

    crossattn_cache["k"].copy_(k)
    crossattn_cache["v"].copy_(v)
    crossattn_cache["is_init"].fill_(True)
```

- This ensures:
  - Cache updates are persistent
  - Behavior is robust to shallow copies or wrappers
  - Cross-attention cache semantics match KV cache semantics

### Impact

✅ Correct and reliable cross-attention caching
✅ Avoids repeated recomputation of cross-attention K/V
✅ No change to public APIs
✅ No change to numerical results
✅ Consistent cache semantics across attention types

### Notes

- This PR assumes that context is already padded to the preallocated cache length (e.g. 512). A shape mismatch will raise an explicit error.
- The change is intentionally minimal and does not alter attention logic or layout.