### PR TITLE
feat(trainium): add explicit NKI rolling-cache attention

### DIFF
--- a/tests/test_nki_attention.py
+++ b/tests/test_nki_attention.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import math
+import importlib.util
+from pathlib import Path
+
+import torch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "wan/modules/nki_attention.py"
+SPEC = importlib.util.spec_from_file_location("self_forcing_nki_attention_test_target", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+NKI_ATTENTION = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(NKI_ATTENTION)
+can_use_nki_attention = NKI_ATTENTION.can_use_nki_attention
+nki_attention = NKI_ATTENTION.nki_attention
+
+
+def _torch_attention_cte(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float):
+    scores = torch.matmul(q.float(), k.float().transpose(-2, -1)) * scale
+    return torch.matmul(torch.softmax(scores, dim=-1), v.float()).to(q.dtype)
+
+
+def test_explicit_nki_layout_matches_unmasked_attention() -> None:
+    torch.manual_seed(7)
+    q = torch.randn(2, 13, 3, 8)
+    k = torch.randn(2, 17, 3, 8)
+    v = torch.randn(2, 17, 3, 8)
+
+    actual = nki_attention(q, k, v, kernel=_torch_attention_cte)
+    expected = torch.nn.functional.scaled_dot_product_attention(
+        q.transpose(1, 2),
+        k.transpose(1, 2),
+        v.transpose(1, 2),
+    ).transpose(1, 2)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_explicit_nki_only_pads_query_to_128_and_preserves_exact_kv() -> None:
+    seen = []
+
+    def kernel(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float):
+        seen.append((tuple(q.shape), tuple(k.shape)))
+        return _torch_attention_cte(q, k, v, scale)
+
+    q = torch.randn(1, 13, 3, 8)
+    k = torch.randn(1, 17, 3, 8)
+    result = nki_attention(q, k, torch.randn_like(k), kernel=kernel)
+
+    assert result.shape == q.shape
+    assert seen == [((3, 128, 8), (3, 17, 8))]
+
+
+def test_explicit_nki_layout_honors_custom_scale() -> None:
+    torch.manual_seed(8)
+    q = torch.randn(1, 11, 2, 8)
+    k = torch.randn(1, 19, 2, 8)
+    v = torch.randn(1, 19, 2, 8)
+    scale = 0.125
+
+    actual = nki_attention(q, k, v, softmax_scale=scale, kernel=_torch_attention_cte)
+    expected = torch.matmul(
+        torch.softmax(
+            torch.matmul(q.transpose(1, 2), k.transpose(1, 2).transpose(-2, -1)) * scale,
+            dim=-1,
+        ),
+        v.transpose(1, 2),
+    ).transpose(1, 2)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_resident_rolling_cache_shape_selects_explicit_nki(monkeypatch) -> None:
+    monkeypatch.setenv("SELF_FORCING_NKI_ATTENTION", "1")
+    q = torch.empty(1, 4680, 12, 128, dtype=torch.bfloat16)
+    k = torch.empty(1, 6240, 12, 128, dtype=torch.bfloat16)
+
+    assert can_use_nki_attention(q, k, torch.empty_like(k), device_type="neuron")
+
+
+def test_initial_equal_length_cache_fill_stays_on_sdpa(monkeypatch) -> None:
+    monkeypatch.setenv("SELF_FORCING_NKI_ATTENTION", "1")
+    q = torch.empty(1, 4680, 12, 128, dtype=torch.bfloat16)
+
+    assert not can_use_nki_attention(q, q, q, device_type="neuron")
+
+
+def test_nki_path_rejects_unimplemented_semantics(monkeypatch) -> None:
+    monkeypatch.setenv("SELF_FORCING_NKI_ATTENTION", "1")
+    q = torch.empty(1, 16, 2, 128, dtype=torch.bfloat16)
+    k = torch.empty(1, 32, 2, 128, dtype=torch.bfloat16)
+
+    assert not can_use_nki_attention(q, k, k, causal=True, device_type="neuron")
+    assert not can_use_nki_attention(q, k, k, dropout_p=0.1, device_type="neuron")
+    assert not can_use_nki_attention(q, k, k, q_lens=[16], device_type="neuron")
+    assert not can_use_nki_attention(q, k, k, window_size=(8, 0), device_type="neuron")
+
+
+def test_default_scale_is_inverse_sqrt_head_dim() -> None:
+    seen = []
+
+    def kernel(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float):
+        seen.append(scale)
+        return torch.zeros_like(q)
+
+    q = torch.zeros(1, 4, 2, 64)
+    k = torch.zeros(1, 8, 2, 64)
+    nki_attention(q, k, torch.zeros_like(k), kernel=kernel)
+
+    assert seen == [1.0 / math.sqrt(64)]

--- a/tests/test_nki_attention.py
+++ b/tests/test_nki_attention.py
@@ -170,6 +170,31 @@ def test_fused_attention_projection_pads_query_and_transposes_linear_weight() ->
     assert seen[0][3] == (1, 16)
 
 
+def test_fused_compiled_layout_can_isolate_only_the_opaque_op(monkeypatch) -> None:
+    monkeypatch.setenv("SELF_FORCING_NKI_ATTENTION_ISOLATE_OP", "1")
+    monkeypatch.setattr(
+        NKI_ATTENTION,
+        "_load_nki_attention_output_projection_op",
+        lambda: _torch_attention_output_projection,
+    )
+    torch.manual_seed(10)
+    q = torch.randn(1, 13, 2, 8)
+    k = torch.randn(1, 17, 2, 8)
+    v = torch.randn_like(k)
+    weight = torch.randn(16, 16)
+    bias = torch.randn(16)
+
+    compiled = torch.compile(
+        nki_attention_output_projection, backend="eager", fullgraph=False
+    )
+    actual = compiled(q, k, v, weight, bias)
+    expected = nki_attention_output_projection(
+        q, k, v, weight, bias, kernel=_torch_attention_output_projection
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
 def test_resident_shape_selects_fused_attention_output_projection(monkeypatch) -> None:
     monkeypatch.setenv("SELF_FORCING_NKI_ATTENTION", "1")
     q = torch.empty(1, 4680, 12, 128, dtype=torch.bfloat16)

--- a/tests/test_nki_attention.py
+++ b/tests/test_nki_attention.py
@@ -7,17 +7,38 @@ from pathlib import Path
 import torch
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "wan/modules/nki_attention.py"
-SPEC = importlib.util.spec_from_file_location("self_forcing_nki_attention_test_target", MODULE_PATH)
+SPEC = importlib.util.spec_from_file_location(
+    "self_forcing_nki_attention_test_target", MODULE_PATH
+)
 assert SPEC is not None and SPEC.loader is not None
 NKI_ATTENTION = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(NKI_ATTENTION)
 can_use_nki_attention = NKI_ATTENTION.can_use_nki_attention
+can_use_nki_attention_output_projection = (
+    NKI_ATTENTION.can_use_nki_attention_output_projection
+)
 nki_attention = NKI_ATTENTION.nki_attention
+nki_attention_output_projection = NKI_ATTENTION.nki_attention_output_projection
 
 
-def _torch_attention_cte(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float):
+def _torch_attention_cte(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float
+):
     scores = torch.matmul(q.float(), k.float().transpose(-2, -1)) * scale
     return torch.matmul(torch.softmax(scores, dim=-1), v.float()).to(q.dtype)
+
+
+def _torch_attention_output_projection(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    attention = _torch_attention_cte(q, k, v, scale)
+    hidden = attention.permute(1, 0, 2).reshape(1, q.shape[1], -1)
+    return torch.matmul(hidden, weight) + bias
 
 
 def test_explicit_nki_layout_matches_unmasked_attention() -> None:
@@ -61,7 +82,8 @@ def test_explicit_nki_layout_honors_custom_scale() -> None:
     actual = nki_attention(q, k, v, softmax_scale=scale, kernel=_torch_attention_cte)
     expected = torch.matmul(
         torch.softmax(
-            torch.matmul(q.transpose(1, 2), k.transpose(1, 2).transpose(-2, -1)) * scale,
+            torch.matmul(q.transpose(1, 2), k.transpose(1, 2).transpose(-2, -1))
+            * scale,
             dim=-1,
         ),
         v.transpose(1, 2),
@@ -108,3 +130,53 @@ def test_default_scale_is_inverse_sqrt_head_dim() -> None:
     nki_attention(q, k, torch.zeros_like(k), kernel=kernel)
 
     assert seen == [1.0 / math.sqrt(64)]
+
+
+def test_fused_attention_output_projection_matches_pytorch() -> None:
+    torch.manual_seed(9)
+    q = torch.randn(1, 13, 3, 8)
+    k = torch.randn(1, 17, 3, 8)
+    v = torch.randn_like(k)
+    weight = torch.randn(24, 24)
+    bias = torch.randn(24)
+
+    actual = nki_attention_output_projection(
+        q, k, v, weight, bias, kernel=_torch_attention_output_projection
+    )
+    attention = torch.nn.functional.scaled_dot_product_attention(
+        q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+    ).transpose(1, 2)
+    expected = torch.nn.functional.linear(attention.flatten(2), weight, bias)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_fused_attention_projection_pads_query_and_transposes_linear_weight() -> None:
+    seen = []
+
+    def kernel(q, k, v, weight, bias, scale):
+        seen.append((tuple(q.shape), tuple(k.shape), weight.clone(), tuple(bias.shape)))
+        return _torch_attention_output_projection(q, k, v, weight, bias, scale)
+
+    q = torch.zeros(1, 13, 2, 8)
+    k = torch.zeros(1, 17, 2, 8)
+    weight = torch.arange(256, dtype=torch.float32).reshape(16, 16)
+    bias = torch.zeros(16)
+    result = nki_attention_output_projection(q, k, k, weight, bias, kernel=kernel)
+
+    assert result.shape == (1, 13, 16)
+    assert seen[0][0:2] == ((2, 128, 8), (2, 17, 8))
+    torch.testing.assert_close(seen[0][2], weight.transpose(0, 1))
+    assert seen[0][3] == (1, 16)
+
+
+def test_resident_shape_selects_fused_attention_output_projection(monkeypatch) -> None:
+    monkeypatch.setenv("SELF_FORCING_NKI_ATTENTION", "1")
+    q = torch.empty(1, 4680, 12, 128, dtype=torch.bfloat16)
+    k = torch.empty(1, 6240, 12, 128, dtype=torch.bfloat16)
+    weight = torch.empty(1536, 1536, dtype=torch.bfloat16)
+    bias = torch.empty(1536, dtype=torch.bfloat16)
+
+    assert can_use_nki_attention_output_projection(
+        q, k, torch.empty_like(k), weight, bias, device_type="neuron"
+    )

--- a/wan/modules/attention.py
+++ b/wan/modules/attention.py
@@ -1,4 +1,6 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import os
+
 import torch
 
 try:
@@ -22,6 +24,12 @@ except ModuleNotFoundError:
 # FLASH_ATTN_3_AVAILABLE = False
 
 import warnings
+
+from wan.modules.nki_attention import (
+    can_use_nki_attention,
+    nki_attention,
+    nki_attention_isolated,
+)
 
 __all__ = [
     'flash_attention',
@@ -151,6 +159,35 @@ def attention(
     dtype=torch.bfloat16,
     fa_version=None,
 ):
+    if q_scale is not None:
+        q = q * q_scale
+
+    if can_use_nki_attention(
+        q,
+        k,
+        v,
+        q_lens=q_lens,
+        k_lens=k_lens,
+        dropout_p=dropout_p,
+        causal=causal,
+        window_size=window_size,
+    ):
+        try:
+            nki_impl = (
+                nki_attention_isolated
+                if os.environ.get("SELF_FORCING_NKI_ISOLATE_OP", "1").strip().lower()
+                in {"1", "true", "yes", "on"}
+                else nki_attention
+            )
+            return nki_impl(q, k, v, softmax_scale=softmax_scale)
+        except BaseException:
+            if _nki_attention_strict():
+                raise
+            warnings.warn(
+                "Self-Forcing NKI attention_cte failed; falling back to PyTorch SDPA.",
+                stacklevel=2,
+            )
+
     if FLASH_ATTN_2_AVAILABLE or FLASH_ATTN_3_AVAILABLE:
         return flash_attention(
             q=q,
@@ -160,7 +197,7 @@ def attention(
             k_lens=k_lens,
             dropout_p=dropout_p,
             softmax_scale=softmax_scale,
-            q_scale=q_scale,
+            q_scale=None,
             causal=causal,
             window_size=window_size,
             deterministic=deterministic,
@@ -183,3 +220,12 @@ def attention(
 
         out = out.transpose(1, 2).contiguous()
         return out
+
+
+def _nki_attention_strict():
+    return os.environ.get("SELF_FORCING_NKI_ATTENTION_STRICT", "1").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }

--- a/wan/modules/attention.py
+++ b/wan/modules/attention.py
@@ -180,7 +180,7 @@ def attention(
                 else nki_attention
             )
             return nki_impl(q, k, v, softmax_scale=softmax_scale)
-        except BaseException:
+        except Exception:
             if _nki_attention_strict():
                 raise
             warnings.warn(

--- a/wan/modules/causal_model.py
+++ b/wan/modules/causal_model.py
@@ -1,4 +1,8 @@
 from wan.modules.attention import attention
+from wan.modules.nki_attention import (
+    can_use_nki_attention_output_projection,
+    nki_attention_output_projection,
+)
 from wan.modules.model import (
     WanRMSNorm,
     rope_apply,
@@ -114,6 +118,7 @@ class CausalWanSelfAttention(nn.Module):
             return q, k, v
 
         q, k, v = qkv_fn(x)
+        output_projected = False
 
         if kv_cache is None:
             # if it is teacher forcing training?
@@ -226,17 +231,22 @@ class CausalWanSelfAttention(nn.Module):
                 local_start_index = local_end_index - num_new_tokens
                 kv_cache["k"][:, local_start_index:local_end_index] = roped_key
                 kv_cache["v"][:, local_start_index:local_end_index] = v
-            x = attention(
-                roped_query,
-                kv_cache["k"][:, max(0, local_end_index - self.max_attention_size):local_end_index],
-                kv_cache["v"][:, max(0, local_end_index - self.max_attention_size):local_end_index]
-            )
+            cached_k = kv_cache["k"][:, max(0, local_end_index - self.max_attention_size):local_end_index]
+            cached_v = kv_cache["v"][:, max(0, local_end_index - self.max_attention_size):local_end_index]
+            if can_use_nki_attention_output_projection(
+                    roped_query, cached_k, cached_v, self.o.weight, self.o.bias):
+                x = nki_attention_output_projection(
+                    roped_query, cached_k, cached_v, self.o.weight, self.o.bias)
+                output_projected = True
+            else:
+                x = attention(roped_query, cached_k, cached_v)
             kv_cache["global_end_index"].fill_(current_end)
             kv_cache["local_end_index"].fill_(local_end_index)
 
         # output
-        x = x.flatten(2)
-        x = self.o(x)
+        if not output_projected:
+            x = x.flatten(2)
+            x = self.o(x)
         return x
 
 

--- a/wan/modules/nki_attention.py
+++ b/wan/modules/nki_attention.py
@@ -21,6 +21,8 @@ _NKI_ATTENTION_OP: Callable[..., torch.Tensor] | None = None
 _NKI_ATTENTION_ERROR: BaseException | None = None
 _NKI_ATTENTION_OUTPUT_PROJECTION_OP: Callable[..., torch.Tensor] | None = None
 _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR: BaseException | None = None
+_NKI_ATTENTION_CTE_KERNEL: Callable[..., Any] | None = None
+_NKI_OUTPUT_PROJECTION_CTE_KERNEL: Callable[..., Any] | None = None
 _NKI_PROJECTION_WEIGHT_CACHE: dict[int, tuple[torch.Tensor, int, torch.Tensor]] = {}
 _NKI_QUERY_TILE = 128
 
@@ -116,8 +118,29 @@ def _load_nki_attention_op() -> Callable[..., torch.Tensor]:
         raise
 
 
+def _attention_output_projection_kernel(q, k, v, weight, bias, scale):
+    attention = _NKI_ATTENTION_CTE_KERNEL(
+        q,
+        k,
+        v,
+        scale=scale,
+        causal_mask=False,
+        tp_q=True,
+        tp_k=True,
+        tp_out=True,
+        cache_softmax=False,
+    )
+    return _NKI_OUTPUT_PROJECTION_CTE_KERNEL(
+        attention.reshape((1, q.shape[0], q.shape[2], q.shape[1])),
+        weight,
+        bias,
+    )
+
+
 def _load_nki_attention_output_projection_op() -> Callable[..., torch.Tensor]:
+    global _NKI_ATTENTION_CTE_KERNEL
     global _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR, _NKI_ATTENTION_OUTPUT_PROJECTION_OP
+    global _NKI_OUTPUT_PROJECTION_CTE_KERNEL
     if _NKI_ATTENTION_OUTPUT_PROJECTION_OP is not None:
         return _NKI_ATTENTION_OUTPUT_PROJECTION_OP
     if _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR is not None:
@@ -134,26 +157,9 @@ def _load_nki_attention_output_projection_op() -> Callable[..., torch.Tensor]:
         from torch_neuronx import nki_op, wrap_nki
         from torch_neuronx.utils import get_logical_neuron_cores
 
-        @nki.jit
-        def attention_output_projection_kernel(q, k, v, weight, bias, scale):
-            attention = attention_cte(
-                q,
-                k,
-                v,
-                scale=scale,
-                causal_mask=False,
-                tp_q=True,
-                tp_k=True,
-                tp_out=True,
-                cache_softmax=False,
-            )
-            return output_projection_cte(
-                attention.reshape((1, q.shape[0], q.shape[2], q.shape[1])),
-                weight,
-                bias,
-            )
-
-        wrapped = wrap_nki(attention_output_projection_kernel)
+        _NKI_ATTENTION_CTE_KERNEL = attention_cte
+        _NKI_OUTPUT_PROJECTION_CTE_KERNEL = output_projection_cte
+        wrapped = wrap_nki(nki.jit(_attention_output_projection_kernel))
 
         @nki_op("self_forcing::attention_output_projection_cte_v1", mutates_args={})
         def attention_output_projection_op(
@@ -274,6 +280,27 @@ def _projection_weight_for_nki(weight: torch.Tensor) -> torch.Tensor:
 
 
 @torch.compiler.disable
+def _invoke_nki_attention_output_projection_isolated(
+    op: Callable[..., torch.Tensor],
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Keep only the opaque NKI call out of the surrounding Wan graph."""
+
+    return op(
+        q,
+        k,
+        v,
+        _projection_weight_for_nki(weight),
+        bias.unsqueeze(0).contiguous(),
+        scale,
+    )
+
+
 def nki_attention_output_projection(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -301,14 +328,25 @@ def nki_attention_output_projection(
         )
 
     op = kernel or _load_nki_attention_output_projection_op()
-    out = op(
-        q_nki,
-        k_nki,
-        v_nki,
-        _projection_weight_for_nki(weight),
-        bias.reshape(1, -1).contiguous(),
-        scale,
-    )
+    if kernel is None and _env_flag("SELF_FORCING_NKI_ATTENTION_ISOLATE_OP", "1"):
+        out = _invoke_nki_attention_output_projection_isolated(
+            op,
+            q_nki,
+            k_nki,
+            v_nki,
+            weight,
+            bias,
+            scale,
+        )
+    else:
+        out = op(
+            q_nki,
+            k_nki,
+            v_nki,
+            _projection_weight_for_nki(weight),
+            bias.unsqueeze(0).contiguous(),
+            scale,
+        )
     return out[:, :q_len].to(q.dtype).reshape(batch, q_len, heads * head_dim)
 
 

--- a/wan/modules/nki_attention.py
+++ b/wan/modules/nki_attention.py
@@ -102,7 +102,7 @@ def _load_nki_attention_op() -> Callable[..., torch.Tensor]:
 
         _NKI_ATTENTION_OP = attention_cte_op
         return attention_cte_op
-    except BaseException as exc:
+    except Exception as exc:
         _NKI_ATTENTION_ERROR = exc
         raise
 

--- a/wan/modules/nki_attention.py
+++ b/wan/modules/nki_attention.py
@@ -19,6 +19,9 @@ import torch
 
 _NKI_ATTENTION_OP: Callable[..., torch.Tensor] | None = None
 _NKI_ATTENTION_ERROR: BaseException | None = None
+_NKI_ATTENTION_OUTPUT_PROJECTION_OP: Callable[..., torch.Tensor] | None = None
+_NKI_ATTENTION_OUTPUT_PROJECTION_ERROR: BaseException | None = None
+_NKI_PROJECTION_WEIGHT_CACHE: dict[int, tuple[torch.Tensor, int, torch.Tensor]] = {}
 _NKI_QUERY_TILE = 128
 
 
@@ -28,6 +31,12 @@ def _env_flag(name: str, default: str = "0") -> bool:
 
 def nki_attention_enabled() -> bool:
     return _env_flag("SELF_FORCING_NKI_ATTENTION", "0")
+
+
+def nki_attention_output_projection_enabled() -> bool:
+    return nki_attention_enabled() and _env_flag(
+        "SELF_FORCING_NKI_ATTENTION_OUTPUT_PROJECTION", "1"
+    )
 
 
 def can_use_nki_attention(
@@ -70,9 +79,9 @@ def _load_nki_attention_op() -> Callable[..., torch.Tensor]:
     if _NKI_ATTENTION_OP is not None:
         return _NKI_ATTENTION_OP
     if _NKI_ATTENTION_ERROR is not None:
-        raise RuntimeError("Self-Forcing NKI attention initialization previously failed") from (
-            _NKI_ATTENTION_ERROR
-        )
+        raise RuntimeError(
+            "Self-Forcing NKI attention initialization previously failed"
+        ) from (_NKI_ATTENTION_ERROR)
 
     try:
         from nkilib.core.attention.attention_cte import attention_cte
@@ -107,11 +116,71 @@ def _load_nki_attention_op() -> Callable[..., torch.Tensor]:
         raise
 
 
+def _load_nki_attention_output_projection_op() -> Callable[..., torch.Tensor]:
+    global _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR, _NKI_ATTENTION_OUTPUT_PROJECTION_OP
+    if _NKI_ATTENTION_OUTPUT_PROJECTION_OP is not None:
+        return _NKI_ATTENTION_OUTPUT_PROJECTION_OP
+    if _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR is not None:
+        raise RuntimeError(
+            "Self-Forcing fused NKI attention/output projection initialization previously failed"
+        ) from _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR
+
+    try:
+        import nki
+        from nkilib.core.attention.attention_cte import attention_cte
+        from nkilib.core.output_projection.output_projection_cte import (
+            output_projection_cte,
+        )
+        from torch_neuronx import nki_op, wrap_nki
+        from torch_neuronx.utils import get_logical_neuron_cores
+
+        @nki.jit
+        def attention_output_projection_kernel(q, k, v, weight, bias, scale):
+            attention = attention_cte(
+                q,
+                k,
+                v,
+                scale=scale,
+                causal_mask=False,
+                tp_q=True,
+                tp_k=True,
+                tp_out=True,
+                cache_softmax=False,
+            )
+            return output_projection_cte(
+                attention.reshape((1, q.shape[0], q.shape[2], q.shape[1])),
+                weight,
+                bias,
+            )
+
+        wrapped = wrap_nki(attention_output_projection_kernel)
+
+        @nki_op("self_forcing::attention_output_projection_cte_v1", mutates_args={})
+        def attention_output_projection_op(
+            q: torch.Tensor,
+            k: torch.Tensor,
+            v: torch.Tensor,
+            weight: torch.Tensor,
+            bias: torch.Tensor,
+            scale: float,
+        ) -> torch.Tensor:
+            grid = (int(get_logical_neuron_cores()),)
+            return wrapped[grid](q, k, v, weight, bias, scale)
+
+        _NKI_ATTENTION_OUTPUT_PROJECTION_OP = attention_output_projection_op
+        return attention_output_projection_op
+    except Exception as exc:
+        _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR = exc
+        raise
+
+
 def initialize_nki_attention() -> None:
     """Register the custom operator before Dynamo traces model execution."""
 
     if nki_attention_enabled():
         _load_nki_attention_op()
+        if nki_attention_output_projection_enabled():
+            _load_nki_attention_output_projection_op()
 
 
 @torch.compiler.disable
@@ -131,13 +200,16 @@ def nki_attention(
     v: torch.Tensor,
     *,
     softmax_scale: float | None = None,
-    kernel: Callable[[torch.Tensor, torch.Tensor, torch.Tensor, float], torch.Tensor] | None = None,
+    kernel: Callable[[torch.Tensor, torch.Tensor, torch.Tensor, float], torch.Tensor]
+    | None = None,
 ) -> torch.Tensor:
     """Run ``[B, S, H, D]`` unmasked attention through NKI ``attention_cte``."""
 
     batch, q_len, heads, head_dim = q.shape
     k_len = k.shape[1]
-    scale = float(softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(head_dim))
+    scale = float(
+        softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(head_dim)
+    )
 
     q_nki = q.permute(0, 2, 1, 3).contiguous().reshape(batch * heads, q_len, head_dim)
     k_nki = k.permute(0, 2, 1, 3).contiguous().reshape(batch * heads, k_len, head_dim)
@@ -159,6 +231,87 @@ def nki_attention(
     return out.reshape(batch, heads, q_len, head_dim).permute(0, 2, 1, 3).contiguous()
 
 
+def can_use_nki_attention_output_projection(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    *,
+    device_type: str | None = None,
+) -> bool:
+    """Return whether the fused resident attention/projection kernel is valid."""
+
+    if not nki_attention_output_projection_enabled():
+        return False
+    if not can_use_nki_attention(q, k, v, device_type=device_type):
+        return False
+    if q.shape[0] != 1 or q.shape[-1] != 128:
+        return False
+    hidden = q.shape[2] * q.shape[3]
+    return (
+        weight.ndim == 2
+        and tuple(weight.shape) == (hidden, hidden)
+        and weight.dtype == q.dtype
+        and bias is not None
+        and bias.ndim == 1
+        and bias.shape[0] == hidden
+        and bias.dtype == q.dtype
+    )
+
+
+def _projection_weight_for_nki(weight: torch.Tensor) -> torch.Tensor:
+    """Cache Linear's [out, in] weight once in NKI's [in, out] layout."""
+
+    cache_key = id(weight)
+    version = int(weight._version)
+    cached = _NKI_PROJECTION_WEIGHT_CACHE.get(cache_key)
+    if cached is not None and cached[0] is weight and cached[1] == version:
+        return cached[2]
+    transposed = weight.detach().transpose(0, 1).contiguous()
+    _NKI_PROJECTION_WEIGHT_CACHE[cache_key] = (weight, version, transposed)
+    return transposed
+
+
+@torch.compiler.disable
+def nki_attention_output_projection(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    *,
+    softmax_scale: float | None = None,
+    kernel: Callable[..., torch.Tensor] | None = None,
+) -> torch.Tensor:
+    """Fuse resident attention and its Linear output projection in one NKI op."""
+
+    batch, q_len, heads, head_dim = q.shape
+    scale = float(
+        softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(head_dim)
+    )
+    q_nki = q.permute(0, 2, 1, 3).contiguous().reshape(heads, q_len, head_dim)
+    k_nki = k.permute(0, 2, 1, 3).contiguous().reshape(heads, k.shape[1], head_dim)
+    v_nki = v.permute(0, 2, 1, 3).contiguous().reshape(heads, v.shape[1], head_dim)
+
+    padded_q_len = math.ceil(q_len / _NKI_QUERY_TILE) * _NKI_QUERY_TILE
+    if padded_q_len != q_len:
+        q_nki = torch.cat(
+            [q_nki, q_nki.new_zeros((heads, padded_q_len - q_len, head_dim))], dim=1
+        )
+
+    op = kernel or _load_nki_attention_output_projection_op()
+    out = op(
+        q_nki,
+        k_nki,
+        v_nki,
+        _projection_weight_for_nki(weight),
+        bias.reshape(1, -1).contiguous(),
+        scale,
+    )
+    return out[:, :q_len].to(q.dtype).reshape(batch, q_len, heads * head_dim)
+
+
 @torch.compiler.disable
 def nki_attention_isolated(
     q: torch.Tensor,
@@ -176,8 +329,19 @@ def nki_attention_status() -> dict[str, Any]:
     return {
         "enabled": nki_attention_enabled(),
         "initialized": _NKI_ATTENTION_OP is not None,
-        "initialization_error": repr(_NKI_ATTENTION_ERROR) if _NKI_ATTENTION_ERROR else None,
+        "initialization_error": repr(_NKI_ATTENTION_ERROR)
+        if _NKI_ATTENTION_ERROR
+        else None,
         "kernel": "nkilib.core.attention.attention_cte",
+        "output_projection_enabled": nki_attention_output_projection_enabled(),
+        "output_projection_initialized": _NKI_ATTENTION_OUTPUT_PROJECTION_OP
+        is not None,
+        "output_projection_initialization_error": repr(
+            _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR
+        )
+        if _NKI_ATTENTION_OUTPUT_PROJECTION_ERROR
+        else None,
+        "output_projection_kernel": "attention_cte(tp_out=True) + output_projection_cte",
         "requires_cache_expansion": True,
         "query_tile": _NKI_QUERY_TILE,
     }

--- a/wan/modules/nki_attention.py
+++ b/wan/modules/nki_attention.py
@@ -1,0 +1,183 @@
+"""Optional AWS NKI attention bridge for Self-Forcing on Trainium.
+
+Torch-Neuron's automatic NKI SDPA lowering requires both sequence dimensions
+to be divisible by 512. Self-Forcing's resident inference shape is 4,680 query
+tokens over a 6,240-token rolling KV cache, so this explicit bridge pads only
+the throwaway query rows required by ``attention_cte``.
+
+All Neuron imports stay lazy so CUDA and CPU users need no AWS dependencies.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+_NKI_ATTENTION_OP: Callable[..., torch.Tensor] | None = None
+_NKI_ATTENTION_ERROR: BaseException | None = None
+_NKI_QUERY_TILE = 128
+
+
+def _env_flag(name: str, default: str = "0") -> bool:
+    return os.environ.get(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def nki_attention_enabled() -> bool:
+    return _env_flag("SELF_FORCING_NKI_ATTENTION", "0")
+
+
+def can_use_nki_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    q_lens: Any = None,
+    k_lens: Any = None,
+    dropout_p: float = 0.0,
+    causal: bool = False,
+    window_size: tuple[int, int] = (-1, -1),
+    device_type: str | None = None,
+) -> bool:
+    """Return whether this call matches the proven ``attention_cte`` contract."""
+
+    if not nki_attention_enabled():
+        return False
+    if (device_type or q.device.type) != "neuron":
+        return False
+    if q_lens is not None or k_lens is not None:
+        return False
+    if dropout_p != 0.0 or causal or window_size != (-1, -1):
+        return False
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4 or k.shape != v.shape:
+        return False
+    if q.shape[0] != k.shape[0] or q.shape[2:] != k.shape[2:]:
+        return False
+    # NeuronXCC currently crashes on Self-Forcing's initial Q=KV=4,680
+    # specialization. Its resident Q=4,680, KV=6,240 specialization is proven.
+    if k.shape[1] <= q.shape[1]:
+        return False
+    if q.shape[-1] not in (64, 128) or q.shape[0] * q.shape[2] > 512:
+        return False
+    return q.dtype in (torch.bfloat16, torch.float16) and k.dtype == q.dtype == v.dtype
+
+
+def _load_nki_attention_op() -> Callable[..., torch.Tensor]:
+    global _NKI_ATTENTION_ERROR, _NKI_ATTENTION_OP
+    if _NKI_ATTENTION_OP is not None:
+        return _NKI_ATTENTION_OP
+    if _NKI_ATTENTION_ERROR is not None:
+        raise RuntimeError("Self-Forcing NKI attention initialization previously failed") from (
+            _NKI_ATTENTION_ERROR
+        )
+
+    try:
+        from nkilib.core.attention.attention_cte import attention_cte
+        from torch_neuronx import nki_op, wrap_nki
+        from torch_neuronx.utils import get_logical_neuron_cores
+
+        wrapped_attention = wrap_nki(attention_cte)
+
+        @nki_op("self_forcing::attention_cte_v1", mutates_args={})
+        def attention_cte_op(
+            q: torch.Tensor,
+            k: torch.Tensor,
+            v: torch.Tensor,
+            scale: float,
+        ) -> torch.Tensor:
+            grid = (int(get_logical_neuron_cores()),)
+            return wrapped_attention[grid](
+                q,
+                k,
+                v,
+                tp_q=True,
+                tp_k=True,
+                scale=scale,
+                causal_mask=False,
+                cache_softmax=False,
+            )
+
+        _NKI_ATTENTION_OP = attention_cte_op
+        return attention_cte_op
+    except BaseException as exc:
+        _NKI_ATTENTION_ERROR = exc
+        raise
+
+
+def initialize_nki_attention() -> None:
+    """Register the custom operator before Dynamo traces model execution."""
+
+    if nki_attention_enabled():
+        _load_nki_attention_op()
+
+
+@torch.compiler.disable
+def _invoke_nki_attention_isolated(
+    op: Callable[..., torch.Tensor],
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    return op(q, k, v, scale)
+
+
+def nki_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    softmax_scale: float | None = None,
+    kernel: Callable[[torch.Tensor, torch.Tensor, torch.Tensor, float], torch.Tensor] | None = None,
+) -> torch.Tensor:
+    """Run ``[B, S, H, D]`` unmasked attention through NKI ``attention_cte``."""
+
+    batch, q_len, heads, head_dim = q.shape
+    k_len = k.shape[1]
+    scale = float(softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(head_dim))
+
+    q_nki = q.permute(0, 2, 1, 3).contiguous().reshape(batch * heads, q_len, head_dim)
+    k_nki = k.permute(0, 2, 1, 3).contiguous().reshape(batch * heads, k_len, head_dim)
+    v_nki = v.permute(0, 2, 1, 3).contiguous().reshape(batch * heads, k_len, head_dim)
+
+    padded_q_len = math.ceil(q_len / _NKI_QUERY_TILE) * _NKI_QUERY_TILE
+    if padded_q_len != q_len:
+        q_nki = torch.cat(
+            [q_nki, q_nki.new_zeros((batch * heads, padded_q_len - q_len, head_dim))],
+            dim=1,
+        )
+
+    op = kernel or _load_nki_attention_op()
+    if kernel is None and _env_flag("SELF_FORCING_NKI_ISOLATE_OP", "1"):
+        out = _invoke_nki_attention_isolated(op, q_nki, k_nki, v_nki, scale)
+    else:
+        out = op(q_nki, k_nki, v_nki, scale)
+    out = out[:, :q_len].to(q.dtype)
+    return out.reshape(batch, heads, q_len, head_dim).permute(0, 2, 1, 3).contiguous()
+
+
+@torch.compiler.disable
+def nki_attention_isolated(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    softmax_scale: float | None = None,
+) -> torch.Tensor:
+    """Keep the complete layout bridge outside the surrounding Dynamo graph."""
+
+    return nki_attention(q, k, v, softmax_scale=softmax_scale)
+
+
+def nki_attention_status() -> dict[str, Any]:
+    return {
+        "enabled": nki_attention_enabled(),
+        "initialized": _NKI_ATTENTION_OP is not None,
+        "initialization_error": repr(_NKI_ATTENTION_ERROR) if _NKI_ATTENTION_ERROR else None,
+        "kernel": "nkilib.core.attention.attention_cte",
+        "requires_cache_expansion": True,
+        "query_tile": _NKI_QUERY_TILE,
+    }


### PR DESCRIPTION
## Summary

- add an opt-in, lazy-imported AWS NKI `attention_cte` bridge for the resident Self-Forcing rolling KV-cache path
- preserve CPU/CUDA behavior when `SELF_FORCING_NKI_ATTENTION` is unset
- isolate the NKI BIR from the surrounding Dynamo graph and leave the compiler-broken initial equal-length cache fill on SDPA
- cover layout conversion, query-only padding, scale semantics, selection, and rejected attention semantics

## Trainium validation

Validated on a Trn2 device with torch-neuronx `2.11.3.0.0+a134947` and NKI Library commit `f6db353a2cc5b10f355ab5f36725e65034aab527`:

- small numerical-equivalence shape: passed
- resident production shape `Q=(1,4680,12,128)`, `KV=(1,6240,12,128)`: compiled and passed
- steady standalone kernel time: **3.85 ms**
- full 9-frame Self-Forcing generation: completed successfully
- initial `Q=KV=4680` specialization exposes an upstream NeuronXCC SIGSEGV and deliberately remains on SDPA

The calling runtime should set `NEURON_PARALLEL_COMPILE_WORKERS=1` and `NEURON_COMPILE_SERVICE_WORKERS=1` during first-request compilation to avoid concurrent compiler memory pressure.

## Tests

- `python -m pytest tests/test_nki_attention.py -q` (7 passed)
- `python -m ruff check wan/modules/nki_attention.py wan/modules/attention.py tests/test_nki_attention.py`
- `git diff --check`